### PR TITLE
Fixes aodn/aodn-portal#2350

### DIFF
--- a/cdm/src/main/java/thredds/crawlabledataset/s3/CrawlableDatasetAmazonS3.java
+++ b/cdm/src/main/java/thredds/crawlabledataset/s3/CrawlableDatasetAmazonS3.java
@@ -75,9 +75,9 @@ public class CrawlableDatasetAmazonS3 extends CrawlableDatasetFile {
     @Override
     public File getFile() {
         try {
-            return threddsS3Client.saveObjectToFile(s3uri, s3uri.getTempFile());
+            return threddsS3Client.getLocalCopy(s3uri);
         } catch (IOException e) {
-            logger.error(String.format("Could not save S3 object '%s' to file.", s3uri), e);
+            logger.error(String.format("Could not get a local copy of '%s'.", s3uri), e);
             return null;
         }
     }

--- a/cdm/src/main/java/thredds/crawlabledataset/s3/ThreddsS3Client.java
+++ b/cdm/src/main/java/thredds/crawlabledataset/s3/ThreddsS3Client.java
@@ -15,50 +15,6 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
  */
 public interface ThreddsS3Client {
     /**
-     * Gets the metadata for the specified Amazon S3 object without actually fetching the object itself.
-     * The object metadata contains information such as content type, content disposition, etc.,
-     * as well as custom user metadata that can be associated with an object in Amazon S3.
-     *
-     * @param s3uri  the Amazon S3 URI of the object whose metadata is being retrieved.
-     * @return all Amazon S3 object metadata for the specified object.
-     *         Will be {@code null} if there is no S3 bucket with the specified name that has the specified key.
-     */
-    ObjectMetadata getObjectMetadata(S3URI s3uri);
-
-    /**
-     * Returns a listing of the objects located in the "virtual filesystem" at the specified URI.
-     * {@code s3uri.getKey()} is interpreted as a path, and only objects (accessible via
-     * {@link ObjectListing#getObjectSummaries}) or "directories" (accessible via
-     * {@link ObjectListing#getCommonPrefixes}) that have that prefix will be part of the returned listing.
-     * <p>
-     * NOTE: To manage large result sets, Amazon S3 uses pagination to split them into multiple responses.
-     * As a consequence, this listing will only include the first 1000-or-so results.
-     * <p>
-     * TODO: Extend this API so that it allows the retrieval of more than 1000 results.
-     *
-     * @param s3uri  the Amazon S3 URI of the "virtual directory" whose objects are being retrieved.
-     * @return  a listing of objects. Will be {@code null} if the specified URI does not denote an existing virtual
-     *          directory. Otherwise, the result will be non-null and non-empty. That is, it will have at least one
-     *          object summary or at least one common prefix.
-     * @see  com.amazonaws.services.s3.AmazonS3#listObjects(String)
-     */
-    ObjectListing listObjects(S3URI s3uri);
-
-    /**
-     * Gets the object metadata for the object stored in Amazon S3 under the specified bucket and key,
-     * and saves the object contents to the specified file.
-     *
-     * @param s3uri  the Amazon S3 URI of the object whose content is being saved.
-     * @param file  indicates the file (which might already exist) where to save the object content being downloading
-     *              from Amazon S3.
-     * @return  the file in which the Amazon S3 object's content was saved.
-     *          Returns {@code null} if there is no S3 bucket with the specified name that has the specified key.
-     * @throws IOException  if some I/O error occurred on the local filesystem while writing to file.
-     */
-
-    File saveObjectToFile(S3URI s3uri, File file) throws IOException;
-
-    /**
      * Returns metadata for the "virtual directory" or S3 object at the specified Amazon S3 URI.
      *
      * @param s3uri  the Amazon S3 URI of the "virtual directory" or S3 object whose metadata is being retrieved.
@@ -77,4 +33,13 @@ public interface ThreddsS3Client {
      */
     ThreddsS3Listing listContents(S3URI s3uri);
 
+    /**
+     * Get a local copy of the object at the specified Amazon S3 URI.
+     *
+     * @param s3uri  the Amazon S3 URI of the object for which a local copy is to be returned.
+     * @return  the file in which the the local copy of the Amazon S3 object's content is saved.
+     *          Returns {@code null} if there is no S3 bucket with the specified name that has the specified key.
+     * @throws IOException  if some I/O error occurred on the local filesystem while writing to file.
+     */
+    File getLocalCopy(S3URI s3uri) throws IOException;
 }

--- a/cdm/src/test/groovy/thredds/crawlabledataset/s3/CachingThreddsS3ClientSpec.groovy
+++ b/cdm/src/test/groovy/thredds/crawlabledataset/s3/CachingThreddsS3ClientSpec.groovy
@@ -1,7 +1,5 @@
 package thredds.crawlabledataset.s3
 
-import com.amazonaws.services.s3.model.ObjectListing
-import com.amazonaws.services.s3.model.ObjectMetadata
 import com.google.common.base.Optional
 import com.google.common.cache.RemovalListener
 import spock.lang.Specification
@@ -19,77 +17,40 @@ class CachingThreddsS3ClientSpec extends Specification {
     RemovalListener<S3URI, Optional<File>> mockRemovalListener = Mock(RemovalListener)
     ThreddsS3Client cachingThreddsS3Client = new CachingThreddsS3Client(mockThreddsS3Client, mockRemovalListener)
 
-    def "getObjectMetadata"() {
-        setup: "create URI and mock return value"
-        S3URI s3uri = new S3URI("s3://bucket/existing-key")
-        ObjectMetadata mockObjectData = Mock(ObjectMetadata)
-
-        when: "caching client's getObjectMetadata() is called twice"
-        cachingThreddsS3Client.getObjectMetadata(s3uri)
-        cachingThreddsS3Client.getObjectMetadata(s3uri)
-
-        then: "mocking client's getObjectMetadata() is called exactly once. It is stubbed to return mockObjectData"
-        1 * mockThreddsS3Client.getObjectMetadata(s3uri) >> mockObjectData
-
-        and: "caching client is returning mockObjectData"
-        cachingThreddsS3Client.getObjectMetadata(s3uri) is mockObjectData
-    }
-
-    def "listObjects"() {
-        setup: "create URI and mock return value"
-        S3URI s3uri = new S3URI("s3://bucket/existing-key")
-        ObjectListing mockObjectListing = Mock(ObjectListing)
-
-        when: "caching client's listObjects() is called twice"
-        cachingThreddsS3Client.listObjects(s3uri)
-        cachingThreddsS3Client.listObjects(s3uri)
-
-        then: "mocking client's listObjects() is called exactly once. It is stubbed to return mockObjectListing"
-        1 * mockThreddsS3Client.listObjects(s3uri) >> mockObjectListing
-
-        and: "caching client is returning mockObjectListing"
-        cachingThreddsS3Client.listObjects(s3uri) is mockObjectListing
-    }
-
-    def "saveObjectToFile - missing key"() {
+    def "download - missing key"() {
         setup: "create URI"
         S3URI s3uri = new S3URI("s3://bucket/missing-key")
-        File file = s3uri.getTempFile();
 
-        when: "caching client's saveObjectToFile() is called twice"
-        cachingThreddsS3Client.saveObjectToFile(s3uri, file)
-        cachingThreddsS3Client.saveObjectToFile(s3uri, file)
+        when: "caching client's getLocalCopy() is called twice"
+        cachingThreddsS3Client.getLocalCopy(s3uri)
+        cachingThreddsS3Client.getLocalCopy(s3uri)
 
-        then: "mocking client's saveObjectToFile() is called exactly once. It is stubbed to return null"
-        1 * mockThreddsS3Client.saveObjectToFile(s3uri, file) >> null
+        then: "mocking client's getLocalCopy() is called exactly once. It is stubbed to return null"
+        1 * mockThreddsS3Client.getLocalCopy(s3uri) >> null
 
         and: "caching client is returning null"
-        cachingThreddsS3Client.saveObjectToFile(s3uri, file) == null
-
-        cleanup: "delete temp file"
-        file?.delete()
+        cachingThreddsS3Client.getLocalCopy(s3uri) == null
     }
 
-    def "saveObjectToFile - redownloading cached file"() {
-        setup: "create URI and File"
+    def "download - redownloading cached file"() {
+        setup: "create URI"
         S3URI s3uri = new S3URI("s3://bucket/dataset.nc")
         File file = createTempFile s3uri
 
         when: "caching client's saveObjectToFile() is called twice"
-        cachingThreddsS3Client.saveObjectToFile(s3uri, file)
-        cachingThreddsS3Client.saveObjectToFile(s3uri, file)
+        cachingThreddsS3Client.getLocalCopy(s3uri)
+        cachingThreddsS3Client.getLocalCopy(s3uri)
 
-        and: "the saved file is deleted"
+        and: "file is deleted"
         Files.delete(file.toPath())
 
         and: "caching client's saveObjectToFile() is called twice more"
-        cachingThreddsS3Client.saveObjectToFile(s3uri, file)
-        cachingThreddsS3Client.saveObjectToFile(s3uri, file)
+        cachingThreddsS3Client.getLocalCopy(s3uri)
+        cachingThreddsS3Client.getLocalCopy(s3uri)
 
-        then: "mocking client's saveObjectToFile() is called exactly twice. It is stubbed to return file"
-        2 * mockThreddsS3Client.saveObjectToFile(s3uri, file) >> {  // This is a closure that generates return values.
+        then: "mocking client's getLocalCopy() is called exactly twice. It is stubbed to return file"
+        2 * mockThreddsS3Client.getLocalCopy(s3uri) >> {  // This is a closure that generates return values.
             if (!file.exists()) {
-                // Before the 2nd call to this method, the file will have been deleted. We must re-create.
                 file.createNewFile()
             }
             file  // Last statement is the (implicit) value of the closure.
@@ -99,34 +60,10 @@ class CachingThreddsS3ClientSpec extends Specification {
         1 * mockRemovalListener.onRemoval({ it.getValue().get() == file })
 
         and: "caching client is returning file"
-        cachingThreddsS3Client.saveObjectToFile(s3uri, file) is file
+        cachingThreddsS3Client.getLocalCopy(s3uri) is file
 
         cleanup: "delete temp file"
         Files.delete(file.toPath())
-    }
-
-    def "saveObjectToFile - download object to 2 different files"() {
-        setup: "create URI and Files"
-        S3URI s3uri = new S3URI("s3://bucket/dataset.nc")
-        File file1 = File.createTempFile("file1", ".nc")
-        File file2 = File.createTempFile("file2", ".nc")
-
-        when: "caching client's saveObjectToFile() is called once with file1 and once with file2"
-        cachingThreddsS3Client.saveObjectToFile(s3uri, file1)
-        cachingThreddsS3Client.saveObjectToFile(s3uri, file2)
-
-        then: "mocking client's saveObjectToFile() is called exactly once. It's stubbed to return file1"
-        1 * mockThreddsS3Client.saveObjectToFile(s3uri, file1) >> file1
-
-        and: "old entry for s3uri was evicted"
-        1 * mockRemovalListener.onRemoval({ it.getKey() == s3uri && it.getValue().get() == file1 })
-
-        and: "caching client is returning file2"
-        cachingThreddsS3Client.saveObjectToFile(s3uri, file2) is file2
-
-        cleanup: "delete temp files"
-        Files.delete(file1.toPath())
-        Files.delete(file2.toPath())
     }
 
     def "clear"() {
@@ -144,12 +81,12 @@ class CachingThreddsS3ClientSpec extends Specification {
         File file3 = createTempFile s3uri3
 
         and: "mocking client's saveObjectToFile() is stubbed to return file1, file2, and file3 in order"
-        mockThreddsS3Client.saveObjectToFile(_, _) >>> [file1, file2, file3]
+        mockThreddsS3Client.getLocalCopy(_) >>> [file1, file2, file3]
 
         expect: "save objects to files, adding them to cache"
-        cachingThreddsS3Client.saveObjectToFile(s3uri1, file1) == file1
-        cachingThreddsS3Client.saveObjectToFile(s3uri2, file2) == file2
-        cachingThreddsS3Client.saveObjectToFile(s3uri3, file3) == file3
+        cachingThreddsS3Client.getLocalCopy(s3uri1) == file1
+        cachingThreddsS3Client.getLocalCopy(s3uri2) == file2
+        cachingThreddsS3Client.getLocalCopy(s3uri3) == file3
 
         and: "files exist"
         file1.exists()


### PR DESCRIPTION
Don't manually manage loading of cache - use googles recommended method of loading the cache which blocks other requests for a key while loading the entry for a key.

Remove old api methods which are no longer used.
