### PR TITLE
fixes #192 - 500 error on empty folder

### DIFF
--- a/cdm/src/main/java/thredds/crawlabledataset/s3/ThreddsS3ClientImpl.java
+++ b/cdm/src/main/java/thredds/crawlabledataset/s3/ThreddsS3ClientImpl.java
@@ -9,6 +9,8 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -127,6 +129,17 @@ public class ThreddsS3ClientImpl implements ThreddsS3Client {
                 }
             }
             objectListing.getObjectSummaries().remove(self);
+
+            // S3 Objects may contain a double slash in the key
+            // similar to an empty folder in a path. Thredds can't handle
+            // these so any key containing a double-slash needs to be exluded
+            List<String> commonPrefixesCopy = new ArrayList<String>(objectListing.getCommonPrefixes());
+
+            for (String commonPrefix: commonPrefixesCopy) {
+                if (commonPrefix.contains("//")) {
+                    objectListing.getCommonPrefixes().remove(commonPrefix);
+                }
+            }
 
             if (objectListing.getObjectSummaries().isEmpty() && objectListing.getCommonPrefixes().isEmpty()) {
                 // There are no empty directories in a S3 hierarchy.


### PR DESCRIPTION
simple solution seems (at least on the surface) to fix issue by removing any prefix with double-slash from s3 object listing. 

That said, I don't think I've got the full handle on thredds so say with confidence whether this is robust. So perhaps someone with excellent thredds knowledge should PR this?

FYI - I tested a few other scenarios that might cause thredds to crash e.g. paths like: 
some/path/./to/some/resource  <-- has '.' 
some/path/../to/some/resource  <-- has '..'

Neither of these cases causes thredds to produce any errors.