### PR TITLE
500 errors reading cached files 2

### DIFF
--- a/cdm/src/main/java/ucar/nc2/NetcdfFile.java
+++ b/cdm/src/main/java/ucar/nc2/NetcdfFile.java
@@ -557,40 +557,27 @@ public class NetcdfFile implements ucar.nc2.util.cache.FileCacheable, Closeable 
         uriString = StringUtil2.unescape(uriString.substring(5));  // 11/10/2010 from erussell@ngs.org
       }
 
-      String uncompressedFileName = null;
-      try {
-        uncompressedFileName = makeUncompressed(uriString);
-      } catch (Exception e) {
-        log.warn("Failed to uncompress {}, err= {}; try as a regular file.", uriString, e.getMessage());
-        //allow to fall through to open the "compressed" file directly - may be a misnamed suffix
-      }
-
-      if (uncompressedFileName != null) {
-        // open uncompressed file as a RandomAccessFile.
+      if (isCompressed(uriString)) {
+        String uncompressedFileName = getFilePrefix(uriString);
         raf = ucar.unidata.io.RandomAccessFile.acquire(uncompressedFileName, buffer_size);
-        //raf = new ucar.unidata.io.MMapRandomAccessFile(uncompressedFileName, "r");
-
-      } else {
-        // normal case - not compressed
-        raf = ucar.unidata.io.RandomAccessFile.acquire(uriString, buffer_size);
-        //raf = new ucar.unidata.io.MMapRandomAccessFile(uriString, "r");
+        try {
+          makeUncompressed(uriString, uncompressedFileName);
+          return raf;
+        } catch (Exception e) {
+          log.warn("Failed to uncompress {}, err= {}; try as a regular file.", uriString, e.getMessage());
+          //allow to fall through to open the "compressed" file directly - may be a misnamed suffix
+        }
       }
+
+      // normal case - not compressed
+      raf = ucar.unidata.io.RandomAccessFile.acquire(uriString, buffer_size);
+
     }
 
     return raf;
   }
 
-  static private String makeUncompressed(String filename) throws Exception {
-    // see if its a compressed file
-    int pos = filename.lastIndexOf('.');
-    if (pos < 0) return null;
-
-    String suffix = filename.substring(pos + 1);
-    String uncompressedFilename = filename.substring(0, pos);
-
-    if (!suffix.equalsIgnoreCase("Z") && !suffix.equalsIgnoreCase("zip") && !suffix.equalsIgnoreCase("gzip")
-            && !suffix.equalsIgnoreCase("gz") && !suffix.equalsIgnoreCase("bz2"))
-      return null;
+  static private String makeUncompressed(String filename, String uncompressedFilename) throws Exception {
 
     // see if already decompressed, look in cache if need be
     File uncompressedFile = DiskCache.getFileStandardPolicy(uncompressedFilename);
@@ -603,7 +590,7 @@ public class NetcdfFile implements ucar.nc2.util.cache.FileCacheable, Closeable 
         // obtain the lock
         while (true) { // loop waiting for the lock
           try {
-            lock = stream.getChannel().lock(0, 1, true); // wait till its unlocked
+            lock = stream.getChannel().lock(0, Long.MAX_VALUE, true); // wait till its unlocked
             break;
 
           } catch (OverlappingFileLockException oe) { // not sure why lock() doesnt block
@@ -635,7 +622,7 @@ public class NetcdfFile implements ucar.nc2.util.cache.FileCacheable, Closeable 
       FileLock lock;
       while (true) { // loop waiting for the lock
         try {
-          lock = fout.getChannel().lock(0, 1, false);
+          lock = fout.getChannel().lock();
           break;
 
         } catch (OverlappingFileLockException oe) { // not sure why lock() doesnt block
@@ -647,6 +634,7 @@ public class NetcdfFile implements ucar.nc2.util.cache.FileCacheable, Closeable 
       }
 
       try {
+        String suffix = getFileSuffix(filename);
         if (suffix.equalsIgnoreCase("Z")) {
           try (InputStream in = new UncompressInputStream(new FileInputStream(filename))) {
             copy(in, fout, 100000);
@@ -2490,6 +2478,58 @@ public class NetcdfFile implements ucar.nc2.util.cache.FileCacheable, Closeable 
     return EscapeStrings.backslashEscape(vname, NetcdfFile.reserved);
   }
 */
+
+
+  /**
+   * Get a filename suffix
+   *
+   * @param filename the file name
+   * @return suffix - eg .gz
+   */
+  static private String getFileSuffix(String filename) {
+
+    int pos = filename.lastIndexOf('.');
+    if (pos < 0) return null;
+
+    String suffix = filename.substring(pos + 1);
+
+    return suffix;
+  }
+
+  /**
+   * Get a filename prefix
+   *
+   * @param filename the file name
+   * @return prefix before the last "."
+   */
+  static private String getFilePrefix(String filename) {
+
+    int pos = filename.lastIndexOf('.');
+    if (pos < 0) return null;
+
+    String prefix = filename.substring(0, pos);
+
+    return prefix;
+
+  }
+
+  /**
+   * Test if a filename might be for a compressed file just by looking at conventional suffixes for compressed files
+   *
+   * @param filename the file name
+   * @return true if it is a compressed file name otherwise false
+   */
+  static private boolean isCompressed(String filename) {
+
+    // see if its a compressed file
+    String suffix = getFileSuffix(filename);
+
+    if (!suffix.equalsIgnoreCase("Z") && !suffix.equalsIgnoreCase("zip") && !suffix.equalsIgnoreCase("gzip")
+            && !suffix.equalsIgnoreCase("gz") && !suffix.equalsIgnoreCase("bz2"))
+      return false;
+
+    return true;
+  }
 
 
 }

--- a/cdm/src/main/java/ucar/unidata/io/RandomAccessFile.java
+++ b/cdm/src/main/java/ucar/unidata/io/RandomAccessFile.java
@@ -190,7 +190,7 @@ public class RandomAccessFile implements DataInput, DataOutput, FileCacheable, C
   static private final ucar.nc2.util.cache.FileFactory factory = new FileFactory() {
     public FileCacheable open(String location, int buffer_size, CancelTask cancelTask, Object iospMessage) throws IOException {
       location = StringUtil2.replace(location, "\\", "/"); // canonicalize the name
-      RandomAccessFile result = new RandomAccessFile(location, "r", buffer_size);
+      RandomAccessFile result = new RandomAccessFile(location, "rw", buffer_size);
       result.cacheState = 1;  // in use
       return result;
     }
@@ -518,6 +518,14 @@ public class RandomAccessFile implements DataInput, DataOutput, FileCacheable, C
 
     bufferStart = pos;
     filePosition = pos;
+
+
+    try {
+      Thread.currentThread().sleep(100);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+
 
     dataSize = read_(pos, buffer, 0, buffer.length);
 


### PR DESCRIPTION
I don't believe this completely fixes the problem or is necessarily the best approach, but it does improve (avoids 500 errors) in my test case.  It would be better to fix the race condition which is occurring in the core Thredds.