### PR TITLE
Updated dependencies in gradle

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -9,21 +9,22 @@ allprojects {  // Doesn't apply any plugins: safe to run closure on all projects
     repositories {
         mavenCentral()
         maven {
-            // JitPack builds GitHub projects on demand and publishes ready-to-use packages.
-            // We need this because Spock requires CGLIB 3.2+ in order to work on Java 8.
-            // However, as of 2015-08-26, v3.2 hasn't been released, even though working code exists on master.
-            // So, using JitPack, we're going to grab an appropriate CGLIB artifact.
-            // See https://github.com/cglib/cglib/issues/32
-            url "https://jitpack.io"  // For libraries["cglib-nodep"]
-        }
-        maven {
-            url "https://artifacts.unidata.ucar.edu/content/repositories/unidata"
-        }
-        maven {
             url "https://artifacts.unidata.ucar.edu/content/repositories/unidata-3rdparty/"
         }
         maven {
             url "http://content.aodn.org.au/repo/maven/"
+        }
+        // For "threddsIso"
+        maven {
+            url "https://artifacts.unidata.ucar.edu/repository/unidata-releases/"
+        }
+        // org.opengis
+        maven {
+            url "http://maven.geotoolkit.org/"
+        }
+        // org.n52.sensorweb
+        maven {
+            url "http://52north.org/maven/repo/releases/"
         }
     }
 }


### PR DESCRIPTION
After reviewing the dependencies in core thredds for both latest version 4.6 and version 5.0 and some Google search I located necessary repositories to enable build with gradle that was no longer working.