### PR TITLE
Revert "500 errors reading cached files 2"

### DIFF
--- a/cdm/src/main/java/ucar/unidata/io/RandomAccessFile.java
+++ b/cdm/src/main/java/ucar/unidata/io/RandomAccessFile.java
@@ -190,7 +190,7 @@ public class RandomAccessFile implements DataInput, DataOutput, FileCacheable, C
   static private final ucar.nc2.util.cache.FileFactory factory = new FileFactory() {
     public FileCacheable open(String location, int buffer_size, CancelTask cancelTask, Object iospMessage) throws IOException {
       location = StringUtil2.replace(location, "\\", "/"); // canonicalize the name
-      RandomAccessFile result = new RandomAccessFile(location, "rw", buffer_size);
+      RandomAccessFile result = new RandomAccessFile(location, "r", buffer_size);
       result.cacheState = 1;  // in use
       return result;
     }
@@ -518,14 +518,6 @@ public class RandomAccessFile implements DataInput, DataOutput, FileCacheable, C
 
     bufferStart = pos;
     filePosition = pos;
-
-
-    try {
-      Thread.currentThread().sleep(100);
-    } catch (InterruptedException e) {
-      e.printStackTrace();
-    }
-
 
     dataSize = read_(pos, buffer, 0, buffer.length);
 


### PR DESCRIPTION
Reverts aodn/thredds#19.  

Refer https://github.com/aodn/issues/issues/259.  Caused a slow down in request processing when released to production pushing many gridded collections into the bad list.