### PR TITLE
Keep copy of metadata in s3 CrawlableDataset...

### DIFF
--- a/cdm/src/main/java/thredds/crawlabledataset/s3/CrawlableDatasetAmazonS3.java
+++ b/cdm/src/main/java/thredds/crawlabledataset/s3/CrawlableDatasetAmazonS3.java
@@ -113,20 +113,13 @@ public class CrawlableDatasetAmazonS3 extends CrawlableDatasetFile {
 
     @Override
     public boolean exists() {
-        if(this.s3Metadata == null) {
-            return threddsS3Client.getMetadata(s3uri) != null;
-        } else {
-            return true;
-        }
+        return getS3Metadata() != null;
     }
 
     @Override
     public boolean isCollection() {
-        if(this.s3Metadata == null) {
-            return true;
-        } else {
-            return this.s3Metadata instanceof ThreddsS3Directory;
-        }
+        return getS3Metadata() instanceof ThreddsS3Directory;
+
     }
 
     @Override
@@ -158,12 +151,10 @@ public class CrawlableDatasetAmazonS3 extends CrawlableDatasetFile {
      */
     @Override
     public long length() {
-        if (this.s3Metadata == null) {
-            this.s3Metadata = threddsS3Client.getMetadata(s3uri);
-        }
+        ThreddsS3Metadata metadata = getS3Metadata();
 
-        if (this.s3Metadata instanceof ThreddsS3Object) {
-            return ((ThreddsS3Object)this.s3Metadata).getLength();
+        if (metadata instanceof ThreddsS3Object) {
+            return ((ThreddsS3Object)metadata).getLength();
         } else {
             // "this" may be a collection or non-existent. In both cases, we return 0.
             return 0;
@@ -177,12 +168,10 @@ public class CrawlableDatasetAmazonS3 extends CrawlableDatasetFile {
      */
     @Override
     public Date lastModified() {
-        if (this.s3Metadata == null) {
-            this.s3Metadata = threddsS3Client.getMetadata(s3uri);
-        }
+        ThreddsS3Metadata metadata = getS3Metadata();
 
-        if (this.s3Metadata instanceof ThreddsS3Object) {
-            return ((ThreddsS3Object)this.s3Metadata).getLastModified();
+        if (metadata instanceof ThreddsS3Object) {
+            return ((ThreddsS3Object)metadata).getLastModified();
         } else {
             // "this" may be a collection or non-existent. In both cases, we return null.
             return null;
@@ -217,5 +206,13 @@ public class CrawlableDatasetAmazonS3 extends CrawlableDatasetFile {
     @Override
     public int hashCode() {
         return Arrays.deepHashCode(new Object[] { this.getS3URI(), this.getConfigObject() });
+    }
+
+    private ThreddsS3Metadata getS3Metadata() {
+        if (this.s3Metadata == null) {
+            this.s3Metadata = threddsS3Client.getMetadata(s3uri);
+        }
+
+        return this.s3Metadata;
     }
 }


### PR DESCRIPTION
... so we don't have to retrieve it with an expensive api call.

Alleviates https://github.com/aodn/issues/issues/348 for most of the big folders, but I found a folder with >250,000 files and it times out on that purely due to the required 250 list-objects api calls, which I don't think we can avoid given we need to know what's in the folder.

This is actually how Dan implemented CrawlableDatasetAmazonS3 in the first place and it was changed at some point, hopefully not for a good reason...